### PR TITLE
audio: effects: Prevent suspension of SW Dolby Atmos effect

### DIFF
--- a/services/audioflinger/Effects.cpp
+++ b/services/audioflinger/Effects.cpp
@@ -2977,6 +2977,11 @@ static const effect_uuid_t SL_IID_DAP_ = { 0x46d279d9, 0x9be7, 0x453d, 0x9d7c,
                                          { 0xef, 0x93, 0x7f, 0x67, 0x55, 0x87 } };
 const effect_uuid_t * const SL_IID_DAP = &SL_IID_DAP_;
 
+// Dolby Atmos SW
+static const effect_uuid_t SL_IID_DAP_SW_ = // 9d4921da-8225-4f29-aefa-39537a04bcaa
+{ 0x9d4921da, 0x8225, 0x4f29, 0xaefa, {0x39, 0x53, 0x7a, 0x04, 0xbc, 0xaa} };
+const effect_uuid_t * const SL_IID_DAP_SW = &SL_IID_DAP_SW_;
+
 /* static */
 bool EffectChain::isEffectEligibleForBtNrecSuspend_l(const effect_uuid_t* type) {
     // Only NS and AEC are suspended when BtNRec is off
@@ -2995,6 +3000,7 @@ bool EffectChain::isEffectEligibleForSuspend(const effect_descriptor_t& desc)
          (memcmp(&desc.type, SL_IID_VISUALIZATION, sizeof(effect_uuid_t)) == 0) ||
          (memcmp(&desc.type, SL_IID_VOLUME, sizeof(effect_uuid_t)) == 0) ||
          (memcmp(&desc.type, SL_IID_DAP, sizeof(effect_uuid_t)) == 0) ||
+         (memcmp(&desc.type, SL_IID_DAP_SW, sizeof(effect_uuid_t)) == 0) ||
          (memcmp(&desc.type, SL_IID_DYNAMICSPROCESSING, sizeof(effect_uuid_t)) == 0))) {
         return false;
     }


### PR DESCRIPTION
The SW Dolby Atmos effect (UUID: 9d4921da-8225-4f29-aefa-39537a04bcaa)
does not properly handle being suspended by the audio framework. Allowing
AudioFlinger to suspend this effect during playback transitions results in 
audio glitches and loss of spatial processing on supported devices.

Add the DAP SW UUID to the suspension bypass list to ensure the effect 
remains active and uninterrupted during audio routing changes.

Change-Id: Iaf2c796f54a4f958d426e6b0d7edd73144dc5fac