### PR TITLE
camera: bypass roundBufferDimensionNearest for Y16

### DIFF
--- a/services/camera/libcameraservice/utils/SessionConfigurationUtils.cpp
+++ b/services/camera/libcameraservice/utils/SessionConfigurationUtils.cpp
@@ -237,7 +237,7 @@ bool roundBufferDimensionNearest(int32_t width, int32_t height,
     // those are not populated in static capabilities.
     if (isPriviledgedClient == true &&
             (format == HAL_PIXEL_FORMAT_YCbCr_420_888 || format == HAL_PIXEL_FORMAT_BLOB ||
-             format == HAL_PIXEL_FORMAT_Y8)) {
+             format == HAL_PIXEL_FORMAT_Y8 || format == HAL_PIXEL_FORMAT_Y16)) {
         ALOGI("Bypass roundBufferDimensionNearest for privilegedClient YUV streams "
                 "width %d height %d for format %d", width, height, format);
 


### PR DESCRIPTION
Used by portrait mode in xiaomi 8650 (peridot) stock camera

540422489 = Y16

202981: 06-07 18:50:30.025  2243  6084 E cameraserver: roundBufferDimensionNearest: No configurations for format 540422489 width 4096, height 3072, maxResolution ? false
Change-Id: I75bac917cc06840ce48ad41d58e3b729f6645221